### PR TITLE
Length and Altitude Extraction

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/buildings/HeightConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/buildings/HeightConverter.java
@@ -10,6 +10,7 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
  *
  * @author matthieun
  */
+@Deprecated
 public class HeightConverter implements StringConverter<Distance>
 {
     private static final String METERS_SUFFIX = " m";

--- a/src/main/java/org/openstreetmap/atlas/tags/BuildingHeightTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/BuildingHeightTag.java
@@ -1,8 +1,12 @@
 package org.openstreetmap.atlas.tags;
 
+import java.util.Optional;
+
+import org.openstreetmap.atlas.geography.Altitude;
 import org.openstreetmap.atlas.tags.annotations.Tag;
 import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
 import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.tags.annotations.extraction.AltitudeExtractor;
 
 /**
  * OSM building:height tag: https://taginfo.openstreetmap.org/keys/building%3Aheight#values. OSM
@@ -10,10 +14,22 @@ import org.openstreetmap.atlas.tags.annotations.TagKey;
  * building:height as well
  *
  * @author isabellehillberg
+ * @author bbreithaupt
  */
 @Tag(value = Validation.LENGTH, taginfo = "https://taginfo.openstreetmap.org/keys/building%3Aheight#values", osm = "http://wiki.openstreetmap.org/wiki/Key:height")
 public interface BuildingHeightTag
 {
     @TagKey
     String KEY = "building:height";
+
+    static Optional<Altitude> get(final Taggable taggable)
+    {
+        final Optional<String> tagValue = taggable.getTag(KEY);
+        if (tagValue.isPresent())
+        {
+            return AltitudeExtractor.validateAndExtract(tagValue.get());
+        }
+
+        return Optional.empty();
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/HeightTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/HeightTag.java
@@ -1,17 +1,33 @@
 package org.openstreetmap.atlas.tags;
 
+import java.util.Optional;
+
+import org.openstreetmap.atlas.geography.Altitude;
 import org.openstreetmap.atlas.tags.annotations.Tag;
 import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
 import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.tags.annotations.extraction.AltitudeExtractor;
 
 /**
  * OSM height tag: http://taginfo.openstreetmap.org/keys/height#values
  *
  * @author cstaylor
+ * @author bbreithaupt
  */
 @Tag(value = Validation.LENGTH, taginfo = "http://taginfo.openstreetmap.org/keys/height#values", osm = "http://wiki.openstreetmap.org/wiki/Key:height")
 public interface HeightTag
 {
     @TagKey
     String KEY = "height";
+
+    static Optional<Altitude> get(final Taggable taggable)
+    {
+        final Optional<String> tagValue = taggable.getTag(KEY);
+        if (tagValue.isPresent())
+        {
+            return AltitudeExtractor.validateAndExtract(tagValue.get());
+        }
+
+        return Optional.empty();
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/MaxHeightTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/MaxHeightTag.java
@@ -1,15 +1,20 @@
 package org.openstreetmap.atlas.tags;
 
+import java.util.Optional;
+
+import org.openstreetmap.atlas.geography.Altitude;
 import org.openstreetmap.atlas.tags.annotations.Tag;
 import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
 import org.openstreetmap.atlas.tags.annotations.TagKey;
 import org.openstreetmap.atlas.tags.annotations.TagValue;
 import org.openstreetmap.atlas.tags.annotations.TagValue.ValueType;
+import org.openstreetmap.atlas.tags.annotations.extraction.AltitudeExtractor;
 
 /**
  * OSM maxheight tag: http://taginfo.openstreetmap.org/keys/maxheight#values
  *
  * @author cstaylor
+ * @author bbreithaupt
  */
 @Tag(value = Validation.DOUBLE, taginfo = "http://taginfo.openstreetmap.org/keys/maxheight#values", osm = "http://wiki.openstreetmap.org/wiki/Key:maxheight")
 public interface MaxHeightTag
@@ -28,4 +33,15 @@ public interface MaxHeightTag
 
     @TagValue(ValueType.REGEX)
     String FEET = "\\d'\\d\"";
+
+    static Optional<Altitude> get(final Taggable taggable)
+    {
+        final Optional<String> tagValue = taggable.getTag(KEY);
+        if (tagValue.isPresent())
+        {
+            return AltitudeExtractor.validateAndExtract(tagValue.get());
+        }
+
+        return Optional.empty();
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/MaxWidthTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/MaxWidthTag.java
@@ -1,14 +1,19 @@
 package org.openstreetmap.atlas.tags;
 
+import java.util.Optional;
+
 import org.openstreetmap.atlas.tags.annotations.Tag;
 import org.openstreetmap.atlas.tags.annotations.TagKey;
 import org.openstreetmap.atlas.tags.annotations.TagValue;
 import org.openstreetmap.atlas.tags.annotations.TagValue.ValueType;
+import org.openstreetmap.atlas.tags.annotations.extraction.LengthExtractor;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
  * OSM maxwidth tag
  *
  * @author cstaylor
+ * @author bbreithaupt
  */
 @Tag(taginfo = "http://taginfo.openstreetmap.org/keys/maxwidth#values", osm = "http://wiki.openstreetmap.org/wiki/Key:maxwidth")
 public interface MaxWidthTag
@@ -21,4 +26,15 @@ public interface MaxWidthTag
 
     @TagValue(ValueType.REGEX)
     String FEET = "\\d'\\d\"";
+
+    static Optional<Distance> get(final Taggable taggable)
+    {
+        final Optional<String> tagValue = taggable.getTag(KEY);
+        if (tagValue.isPresent())
+        {
+            return LengthExtractor.validateAndExtract(tagValue.get());
+        }
+
+        return Optional.empty();
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/MinHeightTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/MinHeightTag.java
@@ -6,12 +6,14 @@ import org.openstreetmap.atlas.geography.Altitude;
 import org.openstreetmap.atlas.tags.annotations.Tag;
 import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
 import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.tags.annotations.extraction.AltitudeExtractor;
 import org.openstreetmap.atlas.tags.annotations.validation.DoubleValidator;
 
 /**
  * OSM min_height tag
  *
  * @author ajayaswal
+ * @author bbreithaupt
  */
 @Tag(value = Validation.DOUBLE, taginfo = "https://taginfo.openstreetmap.org/keys/min_height#values", osm = "https://wiki.openstreetmap.org/wiki/Key:min_height")
 public interface MinHeightTag
@@ -24,10 +26,9 @@ public interface MinHeightTag
     static Optional<Altitude> get(final Taggable taggable)
     {
         final Optional<String> tagValue = taggable.getTag(KEY);
-
-        if (tagValue.isPresent() && validator.isValid(tagValue.get()))
+        if (tagValue.isPresent())
         {
-            return Optional.of(Altitude.meters(Double.valueOf(tagValue.get())));
+            return AltitudeExtractor.validateAndExtract(tagValue.get());
         }
 
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/tags/WidthTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/WidthTag.java
@@ -1,18 +1,34 @@
 package org.openstreetmap.atlas.tags;
 
+import java.util.Optional;
+
 import org.openstreetmap.atlas.tags.annotations.Tag;
 import org.openstreetmap.atlas.tags.annotations.Tag.Range;
 import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
 import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.tags.annotations.extraction.LengthExtractor;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
  * OSM width tag
  *
  * @author cstaylor
+ * @author bbreithaupt
  */
 @Tag(value = Validation.DOUBLE, range = @Range(min = 0, max = Integer.MAX_VALUE), taginfo = "http://taginfo.openstreetmap.org/keys/width#values", osm = "http://wiki.openstreetmap.org/wiki/Key:width")
 public interface WidthTag
 {
     @TagKey
     String KEY = "width";
+
+    static Optional<Distance> get(final Taggable taggable)
+    {
+        final Optional<String> tagValue = taggable.getTag(KEY);
+        if (tagValue.isPresent())
+        {
+            return LengthExtractor.validateAndExtract(tagValue.get());
+        }
+
+        return Optional.empty();
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/AltitudeExtractor.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/AltitudeExtractor.java
@@ -15,11 +15,11 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 public class AltitudeExtractor implements TagExtractor
 {
     /**
-     * Validates and converts a value to a {@link Distance}.
+     * Validates and converts a value to a {@link Altitude}.
      *
      * @param value
      *            {@link String} value.
-     * @return {@link Optional} of a {@link Distance}
+     * @return {@link Optional} of a {@link Altitude}
      */
     public static Optional<Altitude> validateAndExtract(final String value)
     {

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/AltitudeExtractor.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/AltitudeExtractor.java
@@ -1,0 +1,41 @@
+package org.openstreetmap.atlas.tags.annotations.extraction;
+
+import java.util.Optional;
+
+import org.openstreetmap.atlas.geography.Altitude;
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * Extracts a {@link Altitude} from a value. Can be used on tag values such as
+ * {@link org.openstreetmap.atlas.tags.HeightTag}.
+ *
+ * @author bbreithaupt
+ */
+public class AltitudeExtractor implements TagExtractor
+{
+    /**
+     * Validates and converts a value to a {@link Distance}.
+     *
+     * @param value
+     *            {@link String} value.
+     * @return {@link Optional} of a {@link Distance}
+     */
+    public static Optional<Altitude> validateAndExtract(final String value)
+    {
+        if (value.startsWith("-"))
+        {
+            final Optional<Distance> distance = LengthExtractor
+                    .validateAndExtract(value.substring(1));
+            return distance.map(distance1 -> Altitude.meters(distance1.asMeters() * -1));
+        }
+        final Optional<Distance> distance = LengthExtractor.validateAndExtract(value);
+        return distance.map(distance1 -> Altitude.meters(distance1.asMeters()));
+    }
+
+    @Override
+    public Optional<Altitude> validateAndExtract(final String value, final Tag tag)
+    {
+        return AltitudeExtractor.validateAndExtract(value);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/LengthExtractor.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/LengthExtractor.java
@@ -1,0 +1,87 @@
+package org.openstreetmap.atlas.tags.annotations.extraction;
+
+import java.util.Optional;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.validation.LengthValidator;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * Extracts a {@link Distance} from a value. Can be used on tag values such as
+ * {@link org.openstreetmap.atlas.tags.HeightTag}.
+ *
+ * @author bbreithaupt
+ */
+public class LengthExtractor implements TagExtractor
+{
+    private static final LengthValidator VALIDATOR = new LengthValidator();
+    private static final String METERS_SUFFIX = " m";
+    private static final String KILOMETERS_SUFFIX = " km";
+    private static final String MILES_SUFFIX = " mi";
+    private static final String NAUTICAL_MILES_SUFFIX = " nmi";
+
+    /**
+     * Validates and converts a value to a {@link Distance}.
+     *
+     * @param value
+     *            {@link String} value.
+     * @return {@link Optional} of a {@link Distance}
+     */
+    public static Optional<Distance> validateAndExtract(final String value)
+    {
+        if (VALIDATOR.isValid(value))
+        {
+            if (value.endsWith(METERS_SUFFIX))
+            {
+                return Optional.of(Distance.meters(
+                        Double.valueOf(value.substring(0, value.lastIndexOf(METERS_SUFFIX)))));
+            }
+            else if (value.endsWith(KILOMETERS_SUFFIX))
+            {
+                return Optional.of(Distance.kilometers(
+                        Double.valueOf(value.substring(0, value.lastIndexOf(KILOMETERS_SUFFIX)))));
+            }
+            else if (value.endsWith(MILES_SUFFIX))
+            {
+                return Optional.of(Distance.miles(
+                        Double.valueOf(value.substring(0, value.lastIndexOf(MILES_SUFFIX)))));
+            }
+            else if (value.endsWith(NAUTICAL_MILES_SUFFIX))
+            {
+                return Optional.of(Distance.nauticalMiles(Double
+                        .valueOf(value.substring(0, value.lastIndexOf(NAUTICAL_MILES_SUFFIX)))));
+            }
+            else if (value.contains("\""))
+            {
+                final StringList split = StringList.split(value, "\'");
+                if (split.size() == 2)
+                {
+                    return Optional.of(Distance.feetAndInches(Double.valueOf(split.get(0)), Double
+                            .valueOf(split.get(1).substring(0, split.get(1).lastIndexOf("\"")))));
+                }
+                else if (split.size() == 1)
+                {
+                    return Optional.of(Distance.inches(Double
+                            .valueOf(split.get(0).substring(0, split.get(0).lastIndexOf("\"")))));
+                }
+            }
+            else if (value.contains("'"))
+            {
+                return Optional.of(
+                        Distance.feet(Double.valueOf(value.substring(0, value.lastIndexOf("'")))));
+            }
+            else
+            {
+                return Optional.of(Distance.meters(Double.valueOf(value)));
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Distance> validateAndExtract(final String value, final Tag tag)
+    {
+        return LengthExtractor.validateAndExtract(value);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/LengthExtractor.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/LengthExtractor.java
@@ -9,7 +9,7 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
  * Extracts a {@link Distance} from a value. Can be used on tag values such as
- * {@link org.openstreetmap.atlas.tags.HeightTag}.
+ * {@link org.openstreetmap.atlas.tags.WidthTag}.
  *
  * @author bbreithaupt
  */

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/LengthExtractor.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/extraction/LengthExtractor.java
@@ -16,10 +16,7 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 public class LengthExtractor implements TagExtractor
 {
     private static final LengthValidator VALIDATOR = new LengthValidator();
-    private static final String METERS_SUFFIX = " m";
-    private static final String KILOMETERS_SUFFIX = " km";
-    private static final String MILES_SUFFIX = " mi";
-    private static final String NAUTICAL_MILES_SUFFIX = " nmi";
+    private static final String SINGLE_SPACE = " ";
 
     /**
      * Validates and converts a value to a {@link Distance}.
@@ -30,50 +27,55 @@ public class LengthExtractor implements TagExtractor
      */
     public static Optional<Distance> validateAndExtract(final String value)
     {
-        if (VALIDATOR.isValid(value))
+        final String uppercaseValue = value.toUpperCase();
+        if (VALIDATOR.isValid(uppercaseValue))
         {
-            if (value.endsWith(METERS_SUFFIX))
+            if (uppercaseValue.endsWith(SINGLE_SPACE + Distance.UnitAbbreviations.M))
             {
-                return Optional.of(Distance.meters(
-                        Double.valueOf(value.substring(0, value.lastIndexOf(METERS_SUFFIX)))));
+                return Optional.of(Distance.meters(Double.valueOf(uppercaseValue.substring(0,
+                        uppercaseValue.lastIndexOf(SINGLE_SPACE + Distance.UnitAbbreviations.M)))));
             }
-            else if (value.endsWith(KILOMETERS_SUFFIX))
+            else if (uppercaseValue.endsWith(SINGLE_SPACE + Distance.UnitAbbreviations.KM))
             {
-                return Optional.of(Distance.kilometers(
-                        Double.valueOf(value.substring(0, value.lastIndexOf(KILOMETERS_SUFFIX)))));
+                return Optional.of(Distance
+                        .kilometers(Double.valueOf(uppercaseValue.substring(0, uppercaseValue
+                                .lastIndexOf(SINGLE_SPACE + Distance.UnitAbbreviations.KM)))));
             }
-            else if (value.endsWith(MILES_SUFFIX))
+            else if (uppercaseValue.endsWith(SINGLE_SPACE + Distance.UnitAbbreviations.MI))
             {
-                return Optional.of(Distance.miles(
-                        Double.valueOf(value.substring(0, value.lastIndexOf(MILES_SUFFIX)))));
+                return Optional
+                        .of(Distance.miles(Double.valueOf(uppercaseValue.substring(0, uppercaseValue
+                                .lastIndexOf(SINGLE_SPACE + Distance.UnitAbbreviations.MI)))));
             }
-            else if (value.endsWith(NAUTICAL_MILES_SUFFIX))
+            else if (uppercaseValue.endsWith(SINGLE_SPACE + Distance.UnitAbbreviations.NMI))
             {
-                return Optional.of(Distance.nauticalMiles(Double
-                        .valueOf(value.substring(0, value.lastIndexOf(NAUTICAL_MILES_SUFFIX)))));
+                return Optional.of(Distance
+                        .nauticalMiles(Double.valueOf(uppercaseValue.substring(0, uppercaseValue
+                                .lastIndexOf(SINGLE_SPACE + Distance.UnitAbbreviations.NMI)))));
             }
-            else if (value.contains("\""))
+            else if (uppercaseValue.contains(Distance.INCHES_NOTATION))
             {
-                final StringList split = StringList.split(value, "\'");
+                final StringList split = StringList.split(uppercaseValue, Distance.FEET_NOTATION);
                 if (split.size() == 2)
                 {
-                    return Optional.of(Distance.feetAndInches(Double.valueOf(split.get(0)), Double
-                            .valueOf(split.get(1).substring(0, split.get(1).lastIndexOf("\"")))));
+                    return Optional.of(Distance.feetAndInches(Double.valueOf(split.get(0)),
+                            Double.valueOf(split.get(1).substring(0,
+                                    split.get(1).lastIndexOf(Distance.INCHES_NOTATION)))));
                 }
                 else if (split.size() == 1)
                 {
-                    return Optional.of(Distance.inches(Double
-                            .valueOf(split.get(0).substring(0, split.get(0).lastIndexOf("\"")))));
+                    return Optional.of(Distance.inches(Double.valueOf(split.get(0).substring(0,
+                            split.get(0).lastIndexOf(Distance.INCHES_NOTATION)))));
                 }
             }
-            else if (value.contains("'"))
+            else if (uppercaseValue.contains(Distance.FEET_NOTATION))
             {
-                return Optional.of(
-                        Distance.feet(Double.valueOf(value.substring(0, value.lastIndexOf("'")))));
+                return Optional.of(Distance.feet(Double.valueOf(uppercaseValue.substring(0,
+                        uppercaseValue.lastIndexOf(Distance.FEET_NOTATION)))));
             }
             else
             {
-                return Optional.of(Distance.meters(Double.valueOf(value)));
+                return Optional.of(Distance.meters(Double.valueOf(uppercaseValue)));
             }
         }
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidator.java
@@ -1,5 +1,9 @@
 package org.openstreetmap.atlas.tags.annotations.validation;
 
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.commons.lang3.StringUtils;
 import org.openstreetmap.atlas.geography.atlas.items.complex.buildings.HeightConverter;
 
@@ -15,7 +19,10 @@ import org.openstreetmap.atlas.geography.atlas.items.complex.buildings.HeightCon
 public class LengthValidator implements TagValidator
 {
     private static final DoubleValidator DOUBLE_VALIDATOR;
-    private static final String METERS_SUFFIX = " m";
+    private static final String METERS_SUFFIX = "m";
+    private static final String KILOMETERS_SUFFIX = "km";
+    private static final String MILES_SUFFIX = "mi";
+    private static final String NAUTICAL_MILES_SUFFIX = "nmi";
 
     static
     {
@@ -26,9 +33,10 @@ public class LengthValidator implements TagValidator
     /**
      * Validates if the give value is a proper length value.
      * <p>
-     * The expected values are "12.5 m", "12.5", "12'5\"".Incomplete values like "12'"or "5\"" are
-     * also recognized. The method will properly handle malformed values like "Estacion de Servicio
-     * \"Los Arrayanes\"" (contains \ ", but is not a number), "12'err", etc.
+     * The expected values are "12.5 m", "12.5 km", "12.5 mi", "12.5 nmi", "12.5",
+     * "12'5\"".Incomplete values like "12'"or "5\"" are also recognized. The method will properly
+     * handle malformed values like "Estacion de Servicio \"Los Arrayanes\"" (contains \ ", but is
+     * not a number), "12'err", etc.
      * </p>
      */
     @Override
@@ -36,9 +44,17 @@ public class LengthValidator implements TagValidator
     {
         final boolean result;
 
-        if (value.endsWith(METERS_SUFFIX))
+        final Matcher suffixMatcher = Pattern
+                .compile(
+                        String.format("(\\d+.?\\d*) (%s)",
+                                String.join("|",
+                                        Arrays.asList(METERS_SUFFIX, KILOMETERS_SUFFIX,
+                                                MILES_SUFFIX, NAUTICAL_MILES_SUFFIX))))
+                .matcher(value);
+
+        if (suffixMatcher.matches())
         {
-            result = DOUBLE_VALIDATOR.isValid(value.substring(0, value.length() - 2));
+            result = DOUBLE_VALIDATOR.isValid(suffixMatcher.group(1));
         }
         else
         {

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidator.java
@@ -105,9 +105,9 @@ public class LengthValidator implements TagValidator
 
     private boolean validateInchesAndTail(final String value, final int start, final int index)
     {
-        return DOUBLE_VALIDATOR.isValid(value.substring(start, index)) && (
-                index + 1 == value.length() || StringUtils
-                        .isBlank(value.substring(index + 1, value.length())));
+        return DOUBLE_VALIDATOR.isValid(value.substring(start, index))
+                && (index + 1 == value.length()
+                        || StringUtils.isBlank(value.substring(index + 1, value.length())));
     }
 
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidator.java
@@ -27,7 +27,6 @@ public class LengthValidator implements TagValidator
     static
     {
         DOUBLE_VALIDATOR = new DoubleValidator();
-        DOUBLE_VALIDATOR.setMinimum(0);
     }
 
     /**
@@ -106,8 +105,9 @@ public class LengthValidator implements TagValidator
 
     private boolean validateInchesAndTail(final String value, final int start, final int index)
     {
-        return DOUBLE_VALIDATOR.isValid(value.substring(start, index)) ? index + 1 == value.length()
-                || StringUtils.isBlank(value.substring(index + 1, value.length())) : false;
+        return DOUBLE_VALIDATOR.isValid(value.substring(start, index)) && (
+                index + 1 == value.length() || StringUtils
+                        .isBlank(value.substring(index + 1, value.length())));
     }
 
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Distance.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Distance.java
@@ -13,6 +13,20 @@ public final class Distance implements Serializable
 {
     private static final long serialVersionUID = 3728783948477892064L;
 
+    /**
+     * An enum for distance unit abbreviations.
+     */
+    public enum UnitAbbreviations
+    {
+        M,
+        KM,
+        MI,
+        NMI
+    }
+
+    public static final String FEET_NOTATION = "'";
+    public static final String INCHES_NOTATION = "\"";
+
     protected static final long INCHES_PER_FOOT = 12L;
     protected static final long FEET_PER_MILE = 5280;
     protected static final double METERS_PER_FOOT = 0.3048;

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/extraction/AltitudeExtractorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/extraction/AltitudeExtractorTest.java
@@ -1,0 +1,43 @@
+package org.openstreetmap.atlas.tags.annotations.extraction;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Altitude;
+
+/**
+ * Unit test for {@link AltitudeExtractor}.
+ *
+ * @author bbreithaupt
+ */
+public class AltitudeExtractorTest
+{
+    @Test
+    public void validNumberTest()
+    {
+        Assert.assertEquals(Optional.of(Altitude.meters(20.5)),
+                AltitudeExtractor.validateAndExtract("20.5"));
+    }
+
+    @Test
+    public void validMetersTest()
+    {
+        Assert.assertEquals(Optional.of(Altitude.meters(20)),
+                AltitudeExtractor.validateAndExtract("20 m"));
+    }
+
+    @Test
+    public void validNegativeNumberTest()
+    {
+        Assert.assertEquals(Optional.of(Altitude.meters(-20.5)),
+                AltitudeExtractor.validateAndExtract("-20.5"));
+    }
+
+    @Test
+    public void validNegativeMetersTest()
+    {
+        Assert.assertEquals(Optional.of(Altitude.meters(-20)),
+                AltitudeExtractor.validateAndExtract("-20 m"));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/extraction/LengthExtractorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/extraction/LengthExtractorTest.java
@@ -1,0 +1,83 @@
+package org.openstreetmap.atlas.tags.annotations.extraction;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * Unit test for {@link LengthExtractor}.
+ *
+ * @author bbreithaupt
+ */
+public class LengthExtractorTest
+{
+    @Test
+    public void validNumberTest()
+    {
+        Assert.assertEquals(Optional.of(Distance.meters(20.5)),
+                LengthExtractor.validateAndExtract("20.5"));
+    }
+
+    @Test
+    public void validMetersTest()
+    {
+        Assert.assertEquals(Optional.of(Distance.meters(20)),
+                LengthExtractor.validateAndExtract("20 m"));
+    }
+
+    @Test
+    public void validKilometersTest()
+    {
+        Assert.assertEquals(Optional.of(Distance.kilometers(20.5)),
+                LengthExtractor.validateAndExtract("20.5 km"));
+    }
+
+    @Test
+    public void validMilesTest()
+    {
+        Assert.assertEquals(Optional.of(Distance.miles(20.54)),
+                LengthExtractor.validateAndExtract("20.54 mi"));
+    }
+
+    @Test
+    public void validNauticalMilesTest()
+    {
+        Assert.assertEquals(Optional.of(Distance.nauticalMiles(20.543)),
+                LengthExtractor.validateAndExtract("20.543 nmi"));
+    }
+
+    @Test
+    public void validFeetInchesTest()
+    {
+        Assert.assertEquals(Optional.of(Distance.feetAndInches(20, 5)),
+                LengthExtractor.validateAndExtract("20'5\""));
+    }
+
+    @Test
+    public void validFeetTest()
+    {
+        Assert.assertEquals(Optional.of(Distance.feet(20)),
+                LengthExtractor.validateAndExtract("20'"));
+    }
+
+    @Test
+    public void validInchesTest()
+    {
+        Assert.assertEquals(Optional.of(Distance.inches(5)),
+                LengthExtractor.validateAndExtract("5\""));
+    }
+
+    @Test
+    public void invalidMetersTest()
+    {
+        Assert.assertEquals(Optional.empty(), LengthExtractor.validateAndExtract("20m"));
+    }
+
+    @Test
+    public void invalidNumberTest()
+    {
+        Assert.assertEquals(Optional.empty(), LengthExtractor.validateAndExtract("20.s"));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidatorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidatorTest.java
@@ -1,0 +1,68 @@
+package org.openstreetmap.atlas.tags.annotations.validation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link LengthValidator}.
+ *
+ * @author bbreithaupt
+ */
+public class LengthValidatorTest
+{
+    private static final LengthValidator VALIDATOR = new LengthValidator();
+
+    @Test
+    public void validMetersTest()
+    {
+        Assert.assertTrue(VALIDATOR.isValid("123 m"));
+    }
+
+    @Test
+    public void validKilometersTest()
+    {
+        Assert.assertTrue(VALIDATOR.isValid("123.5 km"));
+    }
+
+    @Test
+    public void validMilesTest()
+    {
+        Assert.assertTrue(VALIDATOR.isValid("123.54 mi"));
+    }
+
+    @Test
+    public void validNauticalMilesTest()
+    {
+        Assert.assertTrue(VALIDATOR.isValid("123.543 nmi"));
+    }
+
+    @Test
+    public void invalidFeetInchsTest()
+    {
+        Assert.assertTrue(VALIDATOR.isValid("12'5\""));
+    }
+
+    @Test
+    public void invalidFeetTest()
+    {
+        Assert.assertTrue(VALIDATOR.isValid("12'"));
+    }
+
+    @Test
+    public void invalidInchsTest()
+    {
+        Assert.assertTrue(VALIDATOR.isValid("5\""));
+    }
+
+    @Test
+    public void invalidMetersTest()
+    {
+        Assert.assertFalse(VALIDATOR.isValid("123m"));
+    }
+
+    @Test
+    public void invalidNumberTest()
+    {
+        Assert.assertFalse(VALIDATOR.isValid("123s m"));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidatorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/LengthValidatorTest.java
@@ -13,6 +13,12 @@ public class LengthValidatorTest
     private static final LengthValidator VALIDATOR = new LengthValidator();
 
     @Test
+    public void validNumberTest()
+    {
+        Assert.assertTrue(VALIDATOR.isValid("123.5"));
+    }
+
+    @Test
     public void validMetersTest()
     {
         Assert.assertTrue(VALIDATOR.isValid("123 m"));
@@ -37,7 +43,7 @@ public class LengthValidatorTest
     }
 
     @Test
-    public void invalidFeetInchsTest()
+    public void invalidFeetInchesTest()
     {
         Assert.assertTrue(VALIDATOR.isValid("12'5\""));
     }
@@ -49,7 +55,7 @@ public class LengthValidatorTest
     }
 
     @Test
-    public void invalidInchsTest()
+    public void invalidInchesTest()
     {
         Assert.assertTrue(VALIDATOR.isValid("5\""));
     }


### PR DESCRIPTION
### Description:

This pr adds an improved system for parsing distances from tags. Previously the only handling for this was in the `HeightConverter` class. This improves on that class in several ways. It accounts for all distance units defined by OSM (https://wiki.openstreetmap.org/wiki/Map_Features/Units). Altitude is a separate extractor, so negative values can be extracted. `get` methods have been added to all the appropriate tag classes.
With this updated system, `HeightConverter` is marked as deprecated. 

### Potential Impact:

If the `HeightConverter` class is used in downstream libraries, those references should be switched to the new length or altitude extractor. 

### Unit Test Approach:

Unit test were added for `LengthValidator`, and similar tests have been used for the new extractor classes. Existing unit test for `BuildingHeightTag` and `ComplexBuilding` also confirm this is working as expected. 

### Test Results:

None

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
