### PR TITLE
AbstractAtlasShellToolsCommand Run Without Exiting

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * aid in command development, including some builtin options.
  *
  * @author lcram
+ * @author bbreithaupt
  */
 public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsMarkerInterface
 {

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -621,20 +621,13 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     /**
      * Run this subcommand using all the special setup and teardown semantics provided by
      * {@link AbstractAtlasShellToolsCommand}. It automatically registers some default standard
-     * arguments: (help,h) and (verbose,v). An example of how this method should be called to make
-     * the command functional with an external wrapper:
-     *
-     * <pre>
-     * public static void main(final String[] args)
-     * {
-     *     new MySubclassSubcommand().runSubcommandAndExit(args);
-     * }
-     * </pre>
+     * arguments: (help,h) and (verbose,v).
      *
      * @param args
      *            the command arguments
+     * @return an {@code int} that can be used as a system return code
      */
-    protected void runSubcommandAndExit(final String... args)
+    public int runSubcommand(final String... args)
     {
         throwIfInvalidNameOrDescription();
 
@@ -684,17 +677,36 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
             {
                 printlnStdout(this.getHelpMenu());
             }
-            System.exit(0);
+            return 0;
         }
 
         if (this.parser.hasOption(VERSION_OPTION_LONG))
         {
             printlnStdout(String.format("%s version %s", getCommandName(), this.version));
-            System.exit(0);
+            return 0;
         }
 
         // run the command
-        System.exit(execute());
+        return execute();
+    }
+
+    /**
+     * Run this subcommand and exit the JVM. An example of how this method should be called to make
+     * the command functional with an external wrapper:
+     *
+     * <pre>
+     * public static void main(final String[] args)
+     * {
+     *     new MySubclassSubcommand().runSubcommandAndExit(args);
+     * }
+     * </pre>
+     *
+     * @param args
+     *            the command arguments
+     */
+    public void runSubcommandAndExit(final String... args)
+    {
+        System.exit(this.runSubcommand(args));
     }
 
     /**


### PR DESCRIPTION
### Description:

AbstractAtlasShellToolsCommand.runSubcommandAndExit() calls system.exit(), exiting the JVM when it executes. This modifies AbstractAtlasShellToolsCommand to move the logic for runSubcommandAndExit() to a new public method, runSubcommand(). In doing so the system.exit() calls have been extracted so that they only happen when runSubcommandAndExit() is used. This grants the ability to run a subcommand without exiting the virtual machine, which is helpful for writing unit tests. As runSubcommand() needs to be public for cross package unit testing, runSubcommandAndExit() is also now public to match. 

### Potential Impact:

Grants the ability to run subcommands without exiting.

### Unit Test Approach:

None

### Test Results:

Ran a few subcommands to make sure that the changes are backwards compatible, all ran fine. Tried out the runSubcommand() method by modifying the hello world command, it returned the expected value. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
