### PR TITLE
AtlasFindByAtlasIdentifierSubCommand Special Character Bug Fix

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFindByAtlasIdentifierSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFindByAtlasIdentifierSubCommand.java
@@ -52,9 +52,9 @@ public class AtlasFindByAtlasIdentifierSubCommand extends AbstractAtlasSubComman
     @Override
     public void usage(final PrintStream writer)
     {
-        writer.printf(AtlasCommandConstants.INPUT_PARAMETER_DESCRIPTION);
-        writer.printf("-id=1000000,2000000 : comma separated Atlas identifiers to search for\n");
-        writer.printf("-joinedOutput=path/to/joined.atlas : the path to the output Atlas file\n");
+        writer.print(AtlasCommandConstants.INPUT_PARAMETER_DESCRIPTION);
+        writer.print("-id=1000000,2000000 : comma separated Atlas identifiers to search for%n");
+        writer.print("-joinedOutput=path/to/joined.atlas : the path to the output Atlas file%n");
     }
 
     @Override
@@ -71,7 +71,7 @@ public class AtlasFindByAtlasIdentifierSubCommand extends AbstractAtlasSubComman
         atlas.entities(identifierCheck()).forEach(item ->
         {
             // Print atlas and item information
-            System.out.printf(formatAtlasObject(item));
+            System.out.print(formatAtlasObject(item));
             // Record shard name
             this.shardNames.add(atlas.getName());
         });
@@ -84,7 +84,7 @@ public class AtlasFindByAtlasIdentifierSubCommand extends AbstractAtlasSubComman
         // If joining is requested and there are shards to join...
         if (output.isPresent() && !this.shardNames.isEmpty())
         {
-            System.out.printf("Stitching shards and saving to output %s\n", output.get());
+            System.out.printf("Stitching shards and saving to output %s%n", output.get());
             // Use AtlasJoinerSubCommand to join found atlases
             AtlasReader.main("join",
                     String.format("-input=%s", command.get(super.switches().get(0))),
@@ -117,7 +117,7 @@ public class AtlasFindByAtlasIdentifierSubCommand extends AbstractAtlasSubComman
     private String formatAtlasObject(final AtlasEntity entity)
     {
         final String shardName = entity.getAtlas().metaData().getShardName().orElse("UNKNOWN");
-        return String.format("[%s] [%d] [%d] --> [%s:%s] Tags: [%s]\n", entity.getType(),
+        return String.format("[%s] [%d] [%d] --> [%s:%s] Tags: [%s]%n", entity.getType(),
                 entity.getOsmIdentifier(), entity.getIdentifier(), shardName,
                 entity.getAtlas().getName(), entity.getTags());
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/command/CaptureOutputStream.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/command/CaptureOutputStream.java
@@ -24,6 +24,13 @@ public class CaptureOutputStream extends PrintStream
         return super.printf(format, args);
     }
 
+    @Override
+    public void print(final String string)
+    {
+        this.log = this.log.concat(string);
+        super.print(string);
+    }
+
     public String getLog()
     {
         return this.log;

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/command/DNK_Copenhagen/DNK_2.txt
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/command/DNK_Copenhagen/DNK_2.txt
@@ -2,7 +2,7 @@
 30219770000000 && 55.7612485,12.5333169 && last_edit_user_name -> Hjart || last_edit_changeset -> 14497130 || last_edit_time -> 1357121587000 || last_edit_user_id -> 207581 || iso_country_code -> DNK || last_edit_version -> 4
 5282518816000000 && 55.7611777,12.5338608 && last_edit_user_name -> Hjart || last_edit_changeset -> 54603963 || last_edit_time -> 1513189938000 || last_edit_user_id -> 207581 || iso_country_code -> DNK || last_edit_version -> 1
 # Edges
-546649246000001 && 55.7612485,12.5333169:55.7611777,12.5338608 && last_edit_user_name -> Hjart || last_edit_changeset -> 54603963 || last_edit_time -> 1513189939000 || last_edit_user_id -> 207581 || iso_country_code -> DNK || highway -> service || last_edit_version -> 1
+546649246000001 && 55.7612485,12.5333169:55.7611777,12.5338608 && last_edit_user_name -> Hjart || last_edit_changeset -> 54603963 || last_edit_time -> 1513189939000 || last_edit_user_id -> 207581 || iso_country_code -> DNK || highway -> service || last_edit_version -> 1 || note -> 10% slope
 # Areas
 # Lines
 # Points


### PR DESCRIPTION
### Description:

This fixes a bug with AtlasFindByAtlasIdentifierSubCommand where it would break when the atlas object being returned contained a tag with a percent sign. This was because the `printf` method was being used unnecessarily, causing it to detect the percent sign as a format character. 
Some small sonar code smells were also fixed. 

### Potential Impact:

None

### Unit Test Approach:

One unit test test input was updated to contain a tag with a percent sign.
The custom print stream for unit tests was updated to have a regular print method. 

### Test Results:

Tested on the OSM object that threw the error initially ([way 233363953](https://www.openstreetmap.org/way/233363953)). It finds the object without error now. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
