### PR TITLE
ComplexRoundabout

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundabout.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundabout.java
@@ -137,7 +137,7 @@ public class ComplexRoundabout extends ComplexEntity
      *            An Edge entity in the roundabout adjacent to edge1
      * @return A double corresponding to the cross product between two edges
      */
-    private static Double getCrossProduct(final Edge edge1, final Edge edge2)
+    private static double getCrossProduct(final Edge edge1, final Edge edge2)
     {
         // Get the nodes' latitudes and longitudes to use in deriving the vectors
         final double node1Y = edge1.start().getLocation().getLatitude().asDegrees();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundabout.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundabout.java
@@ -1,0 +1,295 @@
+package org.openstreetmap.atlas.geography.atlas.items.complex.roundabout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Route;
+import org.openstreetmap.atlas.geography.atlas.items.complex.ComplexEntity;
+import org.openstreetmap.atlas.geography.atlas.walker.SimpleEdgeWalker;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
+import org.openstreetmap.atlas.tags.JunctionTag;
+
+/**
+ * A {@link ComplexEntity} representation of a roundabout. To form a valid {@link ComplexRoundabout}
+ * the source {@link Edge} and all connected Edges tagged as a roundabout must meet the following
+ * criteria: be one way; be car navigable; together form a single closed {@link Route} that has the
+ * appropriate directionality based on the country. Adapted from the MalformedRoundaboutCheck in
+ * Atlas-Checks.
+ *
+ * @author bbreithaupt
+ * @author savannahostrowski
+ */
+public class ComplexRoundabout extends ComplexEntity
+{
+    protected static final String WRONG_WAY_INSTRUCTIONS = "This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.";
+    protected static final String INCOMPLETE_ROUTE_INSTRUCTIONS = "This roundabout does not form a single, one-way, complete, car navigable route.";
+
+    private final List<String> invalidationReasons = new ArrayList<>();
+    private Set<Edge> roundaboutEdgeSet;
+    private Route roundaboutRoute;
+
+    /**
+     * An enum of RoundaboutDirections
+     */
+    public enum RoundaboutDirection
+    {
+        CLOCKWISE,
+        COUNTERCLOCKWISE,
+        // Handles the case where we were unable to get any information about the roundabout's
+        // direction.
+        UNKNOWN
+    }
+
+    /**
+     * This method returns a RoundaboutDirection enum which indicates direction of the flow of
+     * traffic based on the cross product of two adjacent edges. This method leverages the
+     * right-hand rule as it relates to the directionality of two vectors.
+     *
+     * @see "https://en.wikipedia.org/wiki/Right-hand_rule"
+     * @param roundaboutEdges
+     *            A list of Edges in a roundabout
+     * @return CLOCKWISE or COUNTERCLOCKWISE if the majority of the edges have positive or negative
+     *         cross products respectively, and UNKNOWN if all edge cross products are 0 or if the
+     *         roundabout's geometry is malformed
+     */
+    private static RoundaboutDirection findRoundaboutDirection(final Route roundaboutEdges)
+    {
+        int clockwiseCount = 0;
+        int counterClockwiseCount = 0;
+
+        for (int idx = 0; idx < roundaboutEdges.size(); idx++)
+        {
+            // Get the Edges to use in the cross product
+            final Edge edge1 = roundaboutEdges.get(idx);
+            // We mod the roundabout edges here so that we can get the last pair of edges in the
+            // Roundabout correctly
+            final Edge edge2 = roundaboutEdges.get((idx + 1) % roundaboutEdges.size());
+            // Get the cross product and then the direction of the roundabout
+            final double crossProduct = getCrossProduct(edge1, edge2);
+            final RoundaboutDirection direction;
+            if (crossProduct < 0)
+            {
+                direction = RoundaboutDirection.COUNTERCLOCKWISE;
+            }
+            else if (crossProduct > 0)
+            {
+                direction = RoundaboutDirection.CLOCKWISE;
+            }
+            else
+            {
+                direction = RoundaboutDirection.UNKNOWN;
+            }
+
+            // If the direction is UNKNOWN then we continue to the next iteration because we do not
+            // Have any new information about the roundabout's direction
+            if (direction.equals(RoundaboutDirection.UNKNOWN))
+            {
+                continue;
+            }
+            if (direction.equals(RoundaboutDirection.CLOCKWISE))
+            {
+                clockwiseCount += 1;
+            }
+            if (direction.equals(RoundaboutDirection.COUNTERCLOCKWISE))
+            {
+                counterClockwiseCount += 1;
+            }
+        }
+        // Return the Enum for whatever has the highest count
+        if (clockwiseCount > counterClockwiseCount)
+        {
+            return RoundaboutDirection.CLOCKWISE;
+        }
+        else if (clockwiseCount < counterClockwiseCount)
+        {
+            return RoundaboutDirection.COUNTERCLOCKWISE;
+        }
+        else
+        {
+            return RoundaboutDirection.UNKNOWN;
+        }
+    }
+
+    /**
+     * This method returns the cross product between two adjacent edges.
+     *
+     * @see "https://en.wikipedia.org/wiki/Cross_product"
+     * @param edge1
+     *            An Edge entity in the roundabout
+     * @param edge2
+     *            An Edge entity in the roundabout adjacent to edge1
+     * @return A double corresponding to the cross product between two edges
+     */
+    private static Double getCrossProduct(final Edge edge1, final Edge edge2)
+    {
+        // Get the nodes' latitudes and longitudes to use in deriving the vectors
+        final double node1Y = edge1.start().getLocation().getLatitude().asDegrees();
+        final double node1X = edge1.start().getLocation().getLongitude().asDegrees();
+        final double node2Y = edge1.end().getLocation().getLatitude().asDegrees();
+        final double node2X = edge1.end().getLocation().getLongitude().asDegrees();
+        final double node3Y = edge2.end().getLocation().getLatitude().asDegrees();
+        final double node3X = edge2.end().getLocation().getLongitude().asDegrees();
+
+        // Get the vectors from node 2 to 1, and node 2 to 3
+        final double vector1X = node2X - node1X;
+        final double vector1Y = node2Y - node1Y;
+        final double vector2X = node2X - node3X;
+        final double vector2Y = node2Y - node3Y;
+
+        // The cross product tells us the direction of the orthogonal vector, which is
+        // Directly related to the direction of rotation/traffic
+        return (vector1X * vector2Y) - (vector1Y * vector2X);
+    }
+
+    public ComplexRoundabout(final Edge source)
+    {
+        this(source, Arrays.asList("AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN",
+                "BWA", "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
+                "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR", "KNA",
+                "LCA", "LKA", "LSO", "MAC", "MDV", "MLT", "MOZ", "MSR", "MUS", "MWI", "MYS", "NAM",
+                "NFK", "NIU", "NPL", "NRU", "NZL", "PAK", "PCN", "PNG", "SGP", "SGS", "SHN", "SLB",
+                "SUR", "SWZ", "SYC", "TCA", "THA", "TKL", "TLS", "TON", "TTO", "TUV", "TZA", "UGA",
+                "VCT", "VGB", "VIR", "WSM", "ZAF", "ZMB", "ZWE"));
+    }
+
+    public ComplexRoundabout(final Edge source, final List leftDrivingCountries)
+    {
+        super(source);
+        try
+        {
+            if (!(
+            // Make sure that the source has an iso_country_code
+            source.getTag(ISOCountryTag.KEY).isPresent()
+                    // Make sure that the source is an instances of a roundabout
+                    && JunctionTag.isRoundabout(source)
+                    // Make sure that we are looking at a master edge
+                    && (source.isMasterEdge())))
+            {
+                throw new CoreException("Invalid source edge for a roundabout.");
+            }
+            final String isoCountryCode = source.tag(ISOCountryTag.KEY).toUpperCase();
+
+            // Get all edges in the roundabout
+            this.roundaboutEdgeSet = new SimpleEdgeWalker(source, this.isRoundaboutEdge())
+                    .collectEdges();
+
+            // Try to build a Route from the edges
+            try
+            {
+                this.roundaboutRoute = Route.fromNonArrangedEdgeSet(this.roundaboutEdgeSet, false);
+            }
+            // If a Route cannot be formed, flag the edges as an incomplete roundabout.
+            catch (final CoreException badRoundabout)
+            {
+                this.invalidationReasons.add(INCOMPLETE_ROUTE_INSTRUCTIONS);
+                throw new CoreException(INCOMPLETE_ROUTE_INSTRUCTIONS);
+            }
+
+            // Flag if any of the edges are not car navigable or master Edges, or the route does not
+            // form a closed loop.
+            if (this.roundaboutEdgeSet.stream()
+                    .anyMatch(roundaboutEdge -> !HighwayTag.isCarNavigableHighway(roundaboutEdge)
+                            || !roundaboutEdge.isMasterEdge())
+                    || !this.roundaboutRoute.start().inEdges().contains(this.roundaboutRoute.end()))
+            {
+                this.invalidationReasons.add(INCOMPLETE_ROUTE_INSTRUCTIONS);
+            }
+
+            // Get the direction of the roundabout
+            final RoundaboutDirection direction = findRoundaboutDirection(this.roundaboutRoute);
+
+            // Determine if the roundabout is in a left or right driving country
+            final boolean isLeftDriving = leftDrivingCountries.contains(isoCountryCode);
+
+            // If the roundabout traffic is clockwise in a right-driving country, or
+            // If the roundabout traffic is counterclockwise in a left-driving country
+            if (direction.equals(RoundaboutDirection.CLOCKWISE) && !isLeftDriving
+                    || direction.equals(RoundaboutDirection.COUNTERCLOCKWISE) && isLeftDriving)
+            {
+                this.invalidationReasons.add(WRONG_WAY_INSTRUCTIONS);
+            }
+            if (!this.invalidationReasons.isEmpty())
+            {
+                throw new CoreException(this.invalidationReasons.get(0));
+            }
+        }
+        catch (final Exception exception)
+        {
+            setInvalidReason(exception.getMessage(), exception);
+        }
+    }
+
+    /**
+     * Function for {@link SimpleEdgeWalker} that gathers connected edges that are part of a
+     * roundabout.
+     *
+     * @return {@link Function} for {@link SimpleEdgeWalker}
+     */
+    private Function<Edge, Stream<Edge>> isRoundaboutEdge()
+    {
+        return edge -> edge.connectedEdges().stream().filter(JunctionTag::isRoundabout);
+    }
+
+    public List<String> getInvalidationReasons()
+    {
+        return this.invalidationReasons;
+    }
+
+    public Set<Edge> getRoundaboutEdgeSet()
+    {
+        return this.roundaboutEdgeSet;
+    }
+
+    public Route getRoundaboutRoute()
+    {
+        return this.roundaboutRoute;
+    }
+
+    @Override
+    public List<ComplexEntityError> getAllInvalidations()
+    {
+        final List<ComplexEntityError> returnValue = new ArrayList<>();
+        if (!isValid())
+        {
+            getError().ifPresent(returnValue::add);
+        }
+        return returnValue;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("Roundabout of Edges: %s", this.roundaboutEdgeSet);
+    }
+
+    @Override
+    public Rectangle bounds()
+    {
+        return this.roundaboutRoute.bounds();
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (other instanceof ComplexRoundabout)
+        {
+            return this.roundaboutEdgeSet
+                    .equals(((ComplexRoundabout) other).getRoundaboutEdgeSet());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundabout.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundabout.java
@@ -32,6 +32,8 @@ public class ComplexRoundabout extends ComplexEntity
     protected static final String WRONG_WAY_INVALIDATION = "This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.";
     protected static final String INCOMPLETE_ROUTE_INVALIDATION = "This roundabout does not form a single, one-way, complete, car navigable route.";
     private static final String EXCEPTION_MESSAGE = "Exception thrown while trying to build a ComplexRoundabout";
+    // Country default source:
+    // https://en.wikipedia.org/wiki/List_of_countries_with_left-hand_traffic
     private static final List<String> LEFT_DRIVING_COUNTRIES_DEFAULT = Arrays.asList("AIA", "ATG",
             "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA", "CCK", "COK", "CXR", "CYM",
             "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD", "GUY", "HKG", "IDN", "IMN", "IND",

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutFinder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutFinder.java
@@ -29,8 +29,11 @@ public class ComplexRoundaboutFinder implements Finder<ComplexRoundabout>
             if (!this.checkedIds.contains(edge.getIdentifier()))
             {
                 final ComplexRoundabout complexRoundabout = new ComplexRoundabout(edge);
-                this.checkedIds.addAll(complexRoundabout.getRoundaboutEdgeSet().stream()
-                        .map(Edge::getIdentifier).collect(Collectors.toSet()));
+                if (complexRoundabout.getRoundaboutEdgeSet() != null)
+                {
+                    this.checkedIds.addAll(complexRoundabout.getRoundaboutEdgeSet().stream()
+                            .map(Edge::getIdentifier).collect(Collectors.toSet()));
+                }
                 if (complexRoundabout.isValid())
                 {
                     complexRoundabouts.add(complexRoundabout);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutFinder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutFinder.java
@@ -1,0 +1,42 @@
+package org.openstreetmap.atlas.geography.atlas.items.complex.roundabout;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.complex.Finder;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+
+/**
+ * {@link Finder} for {@link ComplexRoundabout}s.
+ *
+ * @author bbreithaupt
+ */
+public class ComplexRoundaboutFinder implements Finder<ComplexRoundabout>
+{
+    private final Set<Long> checkedIds = new HashSet<>();
+
+    @Override
+    public Iterable<ComplexRoundabout> find(final Atlas atlas)
+    {
+        final List<ComplexRoundabout> complexRoundabouts = new ArrayList<>();
+        Iterables.stream(atlas.edges()).forEach(edge ->
+        {
+            if (!this.checkedIds.contains(edge.getIdentifier()))
+            {
+                final ComplexRoundabout complexRoundabout = new ComplexRoundabout(edge);
+                this.checkedIds.addAll(complexRoundabout.getRoundaboutEdgeSet().stream()
+                        .map(Edge::getIdentifier).collect(Collectors.toSet()));
+                if (complexRoundabout.isValid())
+                {
+                    complexRoundabouts.add(complexRoundabout);
+                }
+            }
+        });
+        return complexRoundabouts;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutTest.java
@@ -34,7 +34,7 @@ public class ComplexRoundaboutTest
                 this.setup.clockwiseRoundaboutRightDrivingAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
         Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
-        Assert.assertEquals(ComplexRoundabout.WRONG_WAY_INSTRUCTIONS,
+        Assert.assertEquals(ComplexRoundabout.WRONG_WAY_INVALIDATION,
                 complexRoundabout.getInvalidationReasons().get(0));
     }
 
@@ -55,7 +55,7 @@ public class ComplexRoundaboutTest
                 this.setup.counterClockwiseRoundaboutLeftDrivingAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
         Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
-        Assert.assertEquals(ComplexRoundabout.WRONG_WAY_INSTRUCTIONS,
+        Assert.assertEquals(ComplexRoundabout.WRONG_WAY_INVALIDATION,
                 complexRoundabout.getInvalidationReasons().get(0));
     }
 
@@ -75,7 +75,7 @@ public class ComplexRoundaboutTest
                 this.setup.multiDirectionalRoundaboutAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
         Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
-        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
                 complexRoundabout.getInvalidationReasons().get(0));
     }
 
@@ -86,7 +86,7 @@ public class ComplexRoundaboutTest
                 this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
         Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
-        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
                 complexRoundabout.getInvalidationReasons().get(0));
     }
 
@@ -97,7 +97,7 @@ public class ComplexRoundaboutTest
                 this.setup.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
         Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
-        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
                 complexRoundabout.getInvalidationReasons().get(0));
     }
 
@@ -117,7 +117,7 @@ public class ComplexRoundaboutTest
                 this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
         Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
-        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
                 complexRoundabout.getInvalidationReasons().get(0));
     }
 
@@ -128,7 +128,7 @@ public class ComplexRoundaboutTest
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
         Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
-        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
                 complexRoundabout.getInvalidationReasons().get(0));
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutTest.java
@@ -33,9 +33,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.clockwiseRoundaboutRightDrivingAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
         Assert.assertEquals(ComplexRoundabout.WRONG_WAY_INVALIDATION,
-                complexRoundabout.getInvalidationReasons().get(0));
+                complexRoundabout.getAllInvalidations().get(0).getReason());
     }
 
     @Test
@@ -54,9 +54,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.counterClockwiseRoundaboutLeftDrivingAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
         Assert.assertEquals(ComplexRoundabout.WRONG_WAY_INVALIDATION,
-                complexRoundabout.getInvalidationReasons().get(0));
+                complexRoundabout.getAllInvalidations().get(0).getReason());
     }
 
     @Test
@@ -74,9 +74,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.multiDirectionalRoundaboutAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
         Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
-                complexRoundabout.getInvalidationReasons().get(0));
+                complexRoundabout.getAllInvalidations().get(0).getReason());
     }
 
     @Test
@@ -85,9 +85,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
         Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
-                complexRoundabout.getInvalidationReasons().get(0));
+                complexRoundabout.getAllInvalidations().get(0).getReason());
     }
 
     @Test
@@ -96,9 +96,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
         Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
-                complexRoundabout.getInvalidationReasons().get(0));
+                complexRoundabout.getAllInvalidations().get(0).getReason());
     }
 
     @Test
@@ -116,9 +116,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
         Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
-                complexRoundabout.getInvalidationReasons().get(0));
+                complexRoundabout.getAllInvalidations().get(0).getReason());
     }
 
     @Test
@@ -127,9 +127,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
         Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INVALIDATION,
-                complexRoundabout.getInvalidationReasons().get(0));
+                complexRoundabout.getAllInvalidations().get(0).getReason());
     }
 
     @Test
@@ -138,7 +138,7 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.clockwiseRoundaboutRightDrivingIncompleteAtlas().edge(1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(2, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(2, complexRoundabout.getAllInvalidations().size());
     }
 
     @Test
@@ -147,7 +147,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas().edge(1238));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(0, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
+        Assert.assertTrue(complexRoundabout.getAllInvalidations().get(0).getReason()
+                .contains("Invalid source Edge"));
     }
 
     @Test
@@ -156,7 +158,9 @@ public class ComplexRoundaboutTest
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
                 this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas().edge(-1234));
         Assert.assertFalse(complexRoundabout.isValid());
-        Assert.assertEquals(0, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(1, complexRoundabout.getAllInvalidations().size());
+        Assert.assertTrue(complexRoundabout.getAllInvalidations().get(0).getReason()
+                .contains("Invalid source Edge"));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutTest.java
@@ -1,0 +1,179 @@
+package org.openstreetmap.atlas.geography.atlas.items.complex.roundabout;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+
+/**
+ * Unit tests for {@link ComplexRoundabout}.
+ *
+ * @author bbreithaupt
+ */
+public class ComplexRoundaboutTest
+{
+    @Rule
+    public ComplexRoundaboutTestRule setup = new ComplexRoundaboutTestRule();
+
+    @Test
+    public void clockwiseRoundaboutLeftDrivingTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.clockwiseRoundaboutLeftDrivingAtlas().edge(1234));
+        Assert.assertTrue(complexRoundabout.isValid());
+        Assert.assertEquals(5, complexRoundabout.getRoundaboutEdgeSet().size());
+    }
+
+    @Test
+    public void clockwiseRoundaboutRightDrivingTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.clockwiseRoundaboutRightDrivingAtlas().edge(1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(ComplexRoundabout.WRONG_WAY_INSTRUCTIONS,
+                complexRoundabout.getInvalidationReasons().get(0));
+    }
+
+    @Test
+    public void clockwiseRoundaboutRightDrivingMadeLeftDrivingTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.clockwiseRoundaboutRightDrivingAtlas().edge(1234),
+                Collections.singletonList("USA"));
+        Assert.assertTrue(complexRoundabout.isValid());
+        Assert.assertEquals(5, complexRoundabout.getRoundaboutEdgeSet().size());
+    }
+
+    @Test
+    public void counterClockwiseRoundaboutLeftDrivingTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.counterClockwiseRoundaboutLeftDrivingAtlas().edge(1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(ComplexRoundabout.WRONG_WAY_INSTRUCTIONS,
+                complexRoundabout.getInvalidationReasons().get(0));
+    }
+
+    @Test
+    public void counterClockwiseRoundaboutRightDrivingTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.counterClockwiseRoundaboutRightDrivingAtlas().edge(1244));
+        Assert.assertTrue(complexRoundabout.isValid());
+        Assert.assertEquals(5, complexRoundabout.getRoundaboutEdgeSet().size());
+    }
+
+    @Test
+    public void multiDirectionalRoundaboutTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.multiDirectionalRoundaboutAtlas().edge(1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+                complexRoundabout.getInvalidationReasons().get(0));
+    }
+
+    @Test
+    public void clockwiseRoundaboutLeftDrivingMissingTagTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas().edge(1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+                complexRoundabout.getInvalidationReasons().get(0));
+    }
+
+    @Test
+    public void counterClockwiseConnectedDoubleRoundaboutRightDrivingTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas().edge(1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+                complexRoundabout.getInvalidationReasons().get(0));
+    }
+
+    @Test
+    public void counterClockwiseRoundaboutRightDrivingOutsideConnectionTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(this.setup
+                .counterClockwiseRoundaboutRightDrivingOutsideConnectionAtlas().edge(1234));
+        Assert.assertTrue(complexRoundabout.isValid());
+        Assert.assertEquals(5, complexRoundabout.getRoundaboutEdgeSet().size());
+    }
+
+    @Test
+    public void counterClockwiseRoundaboutRightDrivingOneWayNoTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas().edge(1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+                complexRoundabout.getInvalidationReasons().get(0));
+    }
+
+    @Test
+    public void counterClockwiseRoundaboutRightDrivingNonCarNavigableTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas().edge(1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(1, complexRoundabout.getInvalidationReasons().size());
+        Assert.assertEquals(ComplexRoundabout.INCOMPLETE_ROUTE_INSTRUCTIONS,
+                complexRoundabout.getInvalidationReasons().get(0));
+    }
+
+    @Test
+    public void clockwiseRoundaboutRightDrivingIncompleteTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.clockwiseRoundaboutRightDrivingIncompleteAtlas().edge(1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(2, complexRoundabout.getInvalidationReasons().size());
+    }
+
+    @Test
+    public void nonRoundaboutSourceTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas().edge(1238));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(0, complexRoundabout.getInvalidationReasons().size());
+    }
+
+    @Test
+    public void nonMasterSourceTest()
+    {
+        final ComplexRoundabout complexRoundabout = new ComplexRoundabout(
+                this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas().edge(-1234));
+        Assert.assertFalse(complexRoundabout.isValid());
+        Assert.assertEquals(0, complexRoundabout.getInvalidationReasons().size());
+    }
+
+    @Test
+    public void validValidFinderTest()
+    {
+        Assert.assertEquals(2,
+                Iterables.size(new ComplexRoundaboutFinder()
+                        .find(new MultiAtlas(this.setup.clockwiseRoundaboutLeftDrivingAtlas(),
+                                this.setup.counterClockwiseRoundaboutRightDrivingAtlas()))));
+    }
+
+    @Test
+    public void invalidValidFinderTest()
+    {
+        Assert.assertEquals(1,
+                Iterables.size(new ComplexRoundaboutFinder()
+                        .find(new MultiAtlas(this.setup.clockwiseRoundaboutRightDrivingAtlas(),
+                                this.setup.counterClockwiseRoundaboutRightDrivingAtlas()))));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/roundabout/ComplexRoundaboutTestRule.java
@@ -1,0 +1,501 @@
+package org.openstreetmap.atlas.geography.atlas.items.complex.roundabout;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * Unit test rule for {@link ComplexRoundaboutTest}.
+ *
+ * @author bbreithaupt
+ * @author savannahostrowski
+ */
+public class ComplexRoundaboutTestRule extends CoreTestRule
+{
+    private static final String CLOCKWISE_1 = "38.905336130818505,-77.03197002410889";
+    private static final String CLOCKWISE_2 = "38.90558660084624,-77.03158378601074";
+    private static final String CLOCKWISE_3 = "38.905995699991145,-77.0318305492401";
+    private static final String CLOCKWISE_4 = "38.90582872103308,-77.03239917755127";
+    private static final String CLOCKWISE_5 = "38.905494761938684,-77.03236699104309";
+
+    private static final String COUNTER_CLOCKWISE_1 = "38.905361177861046,-77.03205585479736";
+    private static final String COUNTER_CLOCKWISE_2 = "38.905528157918816,-77.03158378601074";
+    private static final String COUNTER_CLOCKWISE_3 = "38.905937257400495,-77.031809091568";
+    private static final String COUNTER_CLOCKWISE_4 = "38.90588716371307,-77.03230261802673";
+    private static final String COUNTER_CLOCKWISE_5 = "38.90551980892527,-77.03236699104309";
+
+    // Clockwise roundabout, left driving country
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(id = "1234", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_1),
+                            @TestAtlas.Loc(value = CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_5),
+                            @TestAtlas.Loc(value = CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_4),
+                            @TestAtlas.Loc(value = CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_3),
+                            @TestAtlas.Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_2),
+                            @TestAtlas.Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }) })
+    private Atlas clockwiseRoundaboutLeftDrivingAtlas;
+
+    // Clockwise roundabout, right driving country
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(id = "1234", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_1),
+                            @TestAtlas.Loc(value = CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_5),
+                            @TestAtlas.Loc(value = CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_4),
+                            @TestAtlas.Loc(value = CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_3),
+                            @TestAtlas.Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_2),
+                            @TestAtlas.Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }) })
+    private Atlas clockwiseRoundaboutRightDrivingAtlas;
+
+    // Counterclockwise roundabout, left driving country
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1234", coordinates = {
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                            "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3) }, tags = {
+                                    "junction=roundabout", "iso_country_code=SGP",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4) }, tags = {
+                                    "junction=roundabout", "iso_country_code=SGP",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5) }, tags = {
+                                    "junction=roundabout", "iso_country_code=SGP",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1) }, tags = {
+                                    "junction=roundabout", "iso_country_code=SGP",
+                                    "highway=primary" }) })
+    private Atlas counterClockwiseRoundaboutLeftDrivingAtlas;
+
+    // Counterclockwise roundabout, right driving country
+    @TestAtlas(
+            // nodes
+            nodes = {
+                    @TestAtlas.Node(id = "10", coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1)),
+                    @TestAtlas.Node(id = "11", coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2)),
+                    @TestAtlas.Node(id = "12", coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3)),
+                    @TestAtlas.Node(id = "13", coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4)),
+                    @TestAtlas.Node(id = "14", coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1244", coordinates = {
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                            "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1245", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1246", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1247", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1248", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }) })
+    private Atlas counterClockwiseRoundaboutRightDrivingAtlas;
+
+    // Multi-directional Atlas
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1234", coordinates = {
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                            "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3),
+                            @TestAtlas.Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_2),
+                            @TestAtlas.Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                            @TestAtlas.Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }) })
+    private Atlas multiDirectionalRoundaboutAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(id = "1234", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_1),
+                            @TestAtlas.Loc(value = CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_5),
+                            @TestAtlas.Loc(value = CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_4),
+                            @TestAtlas.Loc(value = CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_3),
+                            @TestAtlas.Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=SGP", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_2),
+                            @TestAtlas.Loc(value = CLOCKWISE_1) }, tags = { "iso_country_code=SGP",
+                                    "highway=primary" }) })
+    private Atlas clockwiseRoundaboutLeftDrivingMissingTagAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_5)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1234", coordinates = {
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                            "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1239", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                            @TestAtlas.Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1240", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_1),
+                            @TestAtlas.Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1241", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_2),
+                            @TestAtlas.Loc(value = CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1242", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_3),
+                            @TestAtlas.Loc(value = CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1243", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_4),
+                            @TestAtlas.Loc(value = CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1244", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_5),
+                            @TestAtlas.Loc(value = CLOCKWISE_1) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }) })
+    private Atlas counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_4)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1234", coordinates = {
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                            "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1239", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4),
+                            @TestAtlas.Loc(value = CLOCKWISE_4) }, tags = { "iso_country_code=USA",
+                                    "highway=primary" }) })
+    private Atlas counterClockwiseRoundaboutRightDrivingOutsideConnectionAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1234", coordinates = {
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                            "iso_country_code=USA", "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "-1234", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "-1235", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "-1236", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "-1237", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }),
+                    @TestAtlas.Edge(id = "-1238", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary", "oneway=no" }) })
+    private Atlas counterClockwiseRoundaboutRightDrivingOneWayNoAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1234", coordinates = {
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1),
+                    @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2) }, tags = { "junction=roundabout",
+                            "iso_country_code=USA", "highway=elevator" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_2),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_3),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_4),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }),
+                    @TestAtlas.Edge(id = "1238", coordinates = {
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_5),
+                            @TestAtlas.Loc(value = COUNTER_CLOCKWISE_1) }, tags = {
+                                    "junction=roundabout", "iso_country_code=USA",
+                                    "highway=primary" }) })
+    private Atlas counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = CLOCKWISE_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(id = "1234", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_1),
+                            @TestAtlas.Loc(value = CLOCKWISE_5) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1235", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_5),
+                            @TestAtlas.Loc(value = CLOCKWISE_4) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1236", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_4),
+                            @TestAtlas.Loc(value = CLOCKWISE_3) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }),
+                    @TestAtlas.Edge(id = "1237", coordinates = {
+                            @TestAtlas.Loc(value = CLOCKWISE_3),
+                            @TestAtlas.Loc(value = CLOCKWISE_2) }, tags = { "junction=roundabout",
+                                    "iso_country_code=USA", "highway=primary" }) })
+    private Atlas clockwiseRoundaboutRightDrivingIncompleteAtlas;
+
+    public Atlas clockwiseRoundaboutLeftDrivingAtlas()
+    {
+        return this.clockwiseRoundaboutLeftDrivingAtlas;
+    }
+
+    public Atlas clockwiseRoundaboutRightDrivingAtlas()
+    {
+        return this.clockwiseRoundaboutRightDrivingAtlas;
+    }
+
+    public Atlas counterClockwiseRoundaboutLeftDrivingAtlas()
+    {
+        return this.counterClockwiseRoundaboutLeftDrivingAtlas;
+    }
+
+    public Atlas counterClockwiseRoundaboutRightDrivingAtlas()
+    {
+        return this.counterClockwiseRoundaboutRightDrivingAtlas;
+    }
+
+    public Atlas multiDirectionalRoundaboutAtlas()
+    {
+        return this.multiDirectionalRoundaboutAtlas;
+    }
+
+    public Atlas clockwiseRoundaboutLeftDrivingMissingTagAtlas()
+    {
+        return this.clockwiseRoundaboutLeftDrivingMissingTagAtlas;
+    }
+
+    public Atlas counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas()
+    {
+        return this.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas;
+    }
+
+    public Atlas counterClockwiseRoundaboutRightDrivingOutsideConnectionAtlas()
+    {
+        return this.counterClockwiseRoundaboutRightDrivingOutsideConnectionAtlas;
+    }
+
+    public Atlas counterClockwiseRoundaboutRightDrivingOneWayNoAtlas()
+    {
+        return this.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas;
+    }
+
+    public Atlas counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas()
+    {
+        return this.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas;
+    }
+
+    public Atlas clockwiseRoundaboutRightDrivingIncompleteAtlas()
+    {
+        return this.clockwiseRoundaboutRightDrivingIncompleteAtlas;
+    }
+}


### PR DESCRIPTION
### Description:

This adds a new ComplexEntity to represent roundabouts. 
Much of the logic is taken from [Atlas-Checks' MalformedRoundaboutCheck](https://github.com/osmlab/atlas-checks/blob/dev/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java). As such, there are a number of things that can invalidate a ComplexRoundabout. In general, a roundabout must form a single complete one way car navigable ring route that is directionalized in the correct direction for the country the roundabout is in. 
If a Complex Roundabout is valid, it will have a publicly accessible set of Edges that make up the roundabout and a Route built from those Edges. 

### Potential Impact:
No direct downstream impacts, but this can be used to replace some parts of MalformedRoundaboutCheck.

### Unit Test Approach:
The unit tests check a number of correctly and incorrectly formed roundabouts in both right and left driving countries. They check that the correct invalidation reasons are given, and that both constructors work correctly. The ComplexRoundaboutFinder is also tested.

### Test Results:

Tested running a small county through the finder and converting the resulting ComplexRoundabouts' routes into a geojson. A sampling of the results showed that the roundabouts were valid. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
