### PR TITLE
Test Atlas: Apply ISO Country Codes to Features

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/ISOCountryTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/ISOCountryTag.java
@@ -27,7 +27,6 @@ public interface ISOCountryTag
     @TagKey
     String KEY = "iso_country_code";
 
-    String UNKNOWN_ISO_COUNTRY = "UNK";
     String COUNTRY_MISSING = "N/A";
     String COUNTRY_DELIMITER = ",";
 

--- a/src/main/java/org/openstreetmap/atlas/tags/ISOCountryTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/ISOCountryTag.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
  *
  * @author cstaylor
  * @author ahsieh
+ * @author bbreithaupt
  */
 @Tag(Validation.ISO3_COUNTRY)
 public interface ISOCountryTag
@@ -26,6 +27,7 @@ public interface ISOCountryTag
     @TagKey
     String KEY = "iso_country_code";
 
+    String UNKNOWN_ISO_COUNTRY = "UNK";
     String COUNTRY_MISSING = "N/A";
     String COUNTRY_DELIMITER = ",";
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/OsmToAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/OsmToAtlasCommand.java
@@ -11,7 +11,6 @@ import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.OutputStreamWritableResource;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
-import org.openstreetmap.atlas.tags.ISOCountryTag;
 import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
@@ -68,8 +67,7 @@ public class OsmToAtlasCommand extends MultipleOutputCommand
                 final Atlas atlas = TestAtlasHandler.getAtlasFromJsomOsmResource(
                         this.optionAndArgumentDelegate.hasOption(JOSM),
                         new InputStreamResource(() -> new File(absoluteOsmPath.toString()).read()),
-                        absoluteOsmPath.getFileName().toString(),
-                        ISOCountryTag.UNKNOWN_ISO_COUNTRY);
+                        absoluteOsmPath.getFileName().toString());
                 final WritableResource outputResource = new OutputStreamWritableResource(
                         this.getOutputFile(absoluteOsmPath).write());
                 atlas.save(outputResource);

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/OsmToAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/OsmToAtlasCommand.java
@@ -11,6 +11,7 @@ import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.OutputStreamWritableResource;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
 import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
@@ -67,7 +68,8 @@ public class OsmToAtlasCommand extends MultipleOutputCommand
                 final Atlas atlas = TestAtlasHandler.getAtlasFromJsomOsmResource(
                         this.optionAndArgumentDelegate.hasOption(JOSM),
                         new InputStreamResource(() -> new File(absoluteOsmPath.toString()).read()),
-                        absoluteOsmPath.getFileName().toString());
+                        absoluteOsmPath.getFileName().toString(),
+                        ISOCountryTag.UNKNOWN_ISO_COUNTRY);
                 final WritableResource outputResource = new OutputStreamWritableResource(
                         this.getOutputFile(absoluteOsmPath).write());
                 atlas.save(outputResource);

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
@@ -7,7 +7,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
-import org.openstreetmap.atlas.tags.ISOCountryTag;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area.Known;
 
 /**
@@ -272,6 +271,10 @@ public @interface TestAtlas
 
     String DEFAULT_OSM_ID = "<default>";
 
+    // This is for the atlas metadata: we only add the ISO country code if it is something besides
+    // unknown
+    String UNKNOWN_ISO_COUNTRY = "UNKNOWN";
+
     /**
      * Areas we want added to the atlas
      *
@@ -299,7 +302,7 @@ public @interface TestAtlas
      *
      * @return a string containing the ISO3 character code of the country or UNK if not set
      */
-    String iso() default ISOCountryTag.UNKNOWN_ISO_COUNTRY;
+    String iso() default UNKNOWN_ISO_COUNTRY;
 
     /**
      * Lines we want added to the atlas

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area.Known;
 
 /**
@@ -271,10 +272,6 @@ public @interface TestAtlas
 
     String DEFAULT_OSM_ID = "<default>";
 
-    // This is for the atlas metadata: we only add the ISO country code if it is something besides
-    // unknown
-    String UNKNOWN_ISO_COUNTRY = "UNKNOWN";
-
     /**
      * Areas we want added to the atlas
      *
@@ -300,9 +297,9 @@ public @interface TestAtlas
     /**
      * ISO Country Code of the Atlas
      *
-     * @return a string containing the ISO3 character code of the country or UNKNOWN if not set
+     * @return a string containing the ISO3 character code of the country or UNK if not set
      */
-    String iso() default UNKNOWN_ISO_COUNTRY;
+    String iso() default ISOCountryTag.UNKNOWN_ISO_COUNTRY;
 
     /**
      * Lines we want added to the atlas

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
@@ -65,6 +65,13 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.SizeEstimate;
 public class TestAtlasHandler implements FieldHandler
 {
     public static Atlas getAtlasFromJsomOsmResource(final boolean josmFormat,
+            final AbstractResource resource, final String fileName)
+    {
+        return getAtlasFromJsomOsmResource(josmFormat, resource, fileName,
+                ISOCountryTag.UNKNOWN_ISO_COUNTRY);
+    }
+
+    public static Atlas getAtlasFromJsomOsmResource(final boolean josmFormat,
             final AbstractResource resource, final String fileName, final String iso)
     {
         FileSuffix.suffixFor(fileName).ifPresent(suffix ->

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,8 @@ import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.raw.creation.RawAtlasGenerator;
 import org.openstreetmap.atlas.geography.atlas.raw.sectioning.WaySectionProcessor;
+import org.openstreetmap.atlas.geography.atlas.raw.slicing.RawAtlasCountrySlicer;
+import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.AbstractResource;
 import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
@@ -36,6 +39,7 @@ import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.tags.BuildingPartTag;
 import org.openstreetmap.atlas.tags.BuildingTag;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
 import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Maps;
@@ -56,11 +60,12 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.SizeEstimate;
  * Handler implementation for Atlas fields annotated with the TestAtlas annotation
  *
  * @author cstaylor
+ * @author bbreithaupt
  */
 public class TestAtlasHandler implements FieldHandler
 {
     public static Atlas getAtlasFromJsomOsmResource(final boolean josmFormat,
-            final AbstractResource resource, final String fileName)
+            final AbstractResource resource, final String fileName, final String iso)
     {
         FileSuffix.suffixFor(fileName).ifPresent(suffix ->
         {
@@ -81,7 +86,7 @@ public class TestAtlasHandler implements FieldHandler
         {
             new OsmFileToPbf().update(resource, pbfFile);
         }
-        return buildAtlasFromPbf(pbfFile);
+        return buildAtlasFromPbf(pbfFile, iso);
     }
 
     /**
@@ -91,25 +96,33 @@ public class TestAtlasHandler implements FieldHandler
      *
      * @param pbfResource
      *            The pbf input resource to use
+     * @param iso
+     *            ISO code to be applied to all features
      * @return the resulting Atlas
      */
-    private static Atlas buildAtlasFromPbf(final Resource pbfResource)
+    private static Atlas buildAtlasFromPbf(final Resource pbfResource, final String iso)
     {
         // Create raw Atlas
         final AtlasLoadingOption loadingOption = AtlasLoadingOption.withNoFilter();
+        if (!iso.equals(ISOCountryTag.UNKNOWN_ISO_COUNTRY))
+        {
+            loadingOption.setCountrySlicing(true);
+            loadingOption.setCountryBoundaryMap(CountryBoundaryMap
+                    .fromBoundaryMap(Collections.singletonMap(iso, MultiPolygon.MAXIMUM)));
+        }
         final Atlas rawAtlas = new RawAtlasGenerator(pbfResource, loadingOption,
                 MultiPolygon.MAXIMUM).build();
 
-        // Way-section
-        return new WaySectionProcessor(rawAtlas, loadingOption).run();
+        // Country Slice and Way-Section
+        return new WaySectionProcessor(iso.equals(ISOCountryTag.UNKNOWN_ISO_COUNTRY) ? rawAtlas
+                : new RawAtlasCountrySlicer(loadingOption).slice(rawAtlas), loadingOption).run();
     }
 
-    private static Map<String, String> mergeTags(final String[] firstTags,
-            final String[] secondTags)
+    private static String[] mergeTags(final String[] firstTags, final String[] secondTags)
     {
         final List<String> allTags = new ArrayList<>(Arrays.asList(firstTags));
         allTags.addAll(Arrays.asList(secondTags));
-        return parseTags(allTags.toArray(new String[0]));
+        return allTags.toArray(new String[0]);
     }
 
     private static Map<String, String> mergeTags(final Map<String, String> firstTags,
@@ -121,7 +134,7 @@ public class TestAtlasHandler implements FieldHandler
         return returnValue;
     }
 
-    private static Map<String, String> parseTags(final String... tags)
+    private static Map<String, String> parseTags(final String iso, final String... tags)
     {
         final Map<String, String> tagmap = new HashMap<>();
         for (final String tagAndValue : tags)
@@ -142,6 +155,12 @@ public class TestAtlasHandler implements FieldHandler
                 // Erroneous case
                 throw new CoreException("{} isn't a valid tag description", tagAndValue);
             }
+        }
+        // Add a country code if one does not already exist
+        if (!iso.equals(ISOCountryTag.UNKNOWN_ISO_COUNTRY)
+                && !tagmap.containsKey(ISOCountryTag.KEY.toLowerCase()))
+        {
+            tagmap.put(ISOCountryTag.KEY.toLowerCase(), iso);
         }
         return tagmap;
     }
@@ -199,10 +218,11 @@ public class TestAtlasHandler implements FieldHandler
     }
 
     private long addArea(final PackedAtlasBuilder builder, final FeatureIDGenerator areaIDGenerator,
-            final Area area, final String... additionalTags)
+            final Area area, final String iso, final String... additionalTags)
     {
         final long areaId = areaIDGenerator.nextId(area.id());
-        builder.addArea(areaId, buildAreaPolygon(area), mergeTags(area.tags(), additionalTags));
+        builder.addArea(areaId, buildAreaPolygon(area),
+                parseTags(iso, mergeTags(area.tags(), additionalTags)));
         return areaId;
     }
 
@@ -271,7 +291,7 @@ public class TestAtlasHandler implements FieldHandler
         final PackedAtlasBuilder builder = new PackedAtlasBuilder();
         final AtlasSize size = convertSizeEstimates(testAtlas.size());
         final String iso = testAtlas.iso();
-        if (!iso.equals(TestAtlas.UNKNOWN_ISO_COUNTRY))
+        if (!iso.equals(ISOCountryTag.UNKNOWN_ISO_COUNTRY))
         {
             final AtlasMetaData metaData = new AtlasMetaData(size, true, null, null, iso, null,
                     Maps.hashMap());
@@ -281,13 +301,13 @@ public class TestAtlasHandler implements FieldHandler
         {
             builder.setSizeEstimates(size);
         }
-        handle(builder, testAtlas.nodes());
-        handle(builder, testAtlas.edges());
-        handle(builder, testAtlas.areas());
-        handle(builder, testAtlas.lines());
-        handle(builder, testAtlas.points());
-        handle(builder, testAtlas.relations());
-        handle(builder, testAtlas.buildings());
+        handle(builder, iso, testAtlas.nodes());
+        handle(builder, iso, testAtlas.edges());
+        handle(builder, iso, testAtlas.areas());
+        handle(builder, iso, testAtlas.lines());
+        handle(builder, iso, testAtlas.points());
+        handle(builder, iso, testAtlas.relations());
+        handle(builder, iso, testAtlas.buildings());
 
         try
         {
@@ -299,16 +319,17 @@ public class TestAtlasHandler implements FieldHandler
         }
     }
 
-    private void handle(final PackedAtlasBuilder builder, final Area... areas)
+    private void handle(final PackedAtlasBuilder builder, final String iso, final Area... areas)
     {
         final FeatureIDGenerator areaIDGenerator = new FeatureIDGenerator();
         for (final Area area : areas)
         {
-            addArea(builder, areaIDGenerator, area);
+            addArea(builder, areaIDGenerator, area, iso);
         }
     }
 
-    private void handle(final PackedAtlasBuilder builder, final Building... buildings)
+    private void handle(final PackedAtlasBuilder builder, final String iso,
+            final Building... buildings)
     {
         final FeatureIDGenerator buildingGenerator = new FeatureIDGenerator();
         for (final Building building : buildings)
@@ -317,14 +338,14 @@ public class TestAtlasHandler implements FieldHandler
             final TreeSet<Long> innerIds = new TreeSet<>();
             final TreeSet<Long> partIds = new TreeSet<>();
 
-            outerIds.add(addArea(builder, buildingGenerator, building.outer()));
+            outerIds.add(addArea(builder, buildingGenerator, building.outer(), iso));
             for (final Area inner : building.inners())
             {
-                innerIds.add(addArea(builder, buildingGenerator, inner));
+                innerIds.add(addArea(builder, buildingGenerator, inner, iso));
             }
             for (final Area part : building.parts())
             {
-                partIds.add(addArea(builder, buildingGenerator, part, BuildingPartTag.KEY,
+                partIds.add(addArea(builder, buildingGenerator, part, iso, BuildingPartTag.KEY,
                         BuildingPartTag.YES.getTagValue()));
             }
 
@@ -338,7 +359,7 @@ public class TestAtlasHandler implements FieldHandler
 
             final long outlineId = buildingGenerator.nextId(TestAtlas.AUTO_GENERATED);
             builder.addRelation(outlineId, outlineId, outline,
-                    mergeTags(parseTags(building.outlineTags()),
+                    mergeTags(parseTags(iso, building.outlineTags()),
                             Validators.toMap(RelationTypeTag.MULTIPOLYGON)));
 
             final RelationBean multipart = new RelationBean();
@@ -350,51 +371,52 @@ public class TestAtlasHandler implements FieldHandler
 
             final long buildingId = buildingGenerator.nextId(TestAtlas.AUTO_GENERATED);
             builder.addRelation(buildingId, buildingId, multipart, mergeTags(
-                    parseTags(building.tags()), Validators.toMap(RelationTypeTag.BUILDING)));
+                    parseTags(iso, building.tags()), Validators.toMap(RelationTypeTag.BUILDING)));
         }
     }
 
-    private void handle(final PackedAtlasBuilder builder, final Edge... edges)
+    private void handle(final PackedAtlasBuilder builder, final String iso, final Edge... edges)
     {
         final FeatureIDGenerator edgeIDGenerator = new FeatureIDGenerator();
         for (final Edge edge : edges)
         {
             builder.addEdge(edgeIDGenerator.nextId(edge.id()), convertPolyLine(edge.coordinates()),
-                    parseTags(edge.tags()));
+                    parseTags(iso, edge.tags()));
         }
     }
 
-    private void handle(final PackedAtlasBuilder builder, final Line... lines)
+    private void handle(final PackedAtlasBuilder builder, final String iso, final Line... lines)
     {
         final FeatureIDGenerator lineIDGenerator = new FeatureIDGenerator();
         for (final Line line : lines)
         {
             builder.addLine(lineIDGenerator.nextId(line.id()), convertPolyLine(line.coordinates()),
-                    parseTags(line.tags()));
+                    parseTags(iso, line.tags()));
         }
     }
 
-    private void handle(final PackedAtlasBuilder builder, final Node... nodes)
+    private void handle(final PackedAtlasBuilder builder, final String iso, final Node... nodes)
     {
         final FeatureIDGenerator nodeIDGenerator = new FeatureIDGenerator();
         for (final Node node : nodes)
         {
             builder.addNode(nodeIDGenerator.nextId(node.id()), convertLoc(node.coordinates()),
-                    parseTags(node.tags()));
+                    parseTags(iso, node.tags()));
         }
     }
 
-    private void handle(final PackedAtlasBuilder builder, final Point... points)
+    private void handle(final PackedAtlasBuilder builder, final String iso, final Point... points)
     {
         final FeatureIDGenerator pointIDGenerator = new FeatureIDGenerator();
         for (final Point point : points)
         {
             builder.addPoint(pointIDGenerator.nextId(point.id()), convertLoc(point.coordinates()),
-                    parseTags(point.tags()));
+                    parseTags(iso, point.tags()));
         }
     }
 
-    private void handle(final PackedAtlasBuilder builder, final Relation... relations)
+    private void handle(final PackedAtlasBuilder builder, final String iso,
+            final Relation... relations)
     {
         final FeatureIDGenerator relationIDGenerator = new FeatureIDGenerator();
         for (final Relation relation : relations)
@@ -409,7 +431,7 @@ public class TestAtlasHandler implements FieldHandler
             final long osmIdentifier = relation.osmId().equals(TestAtlas.DEFAULT_OSM_ID)
                     ? identifier
                     : relationIDGenerator.nextId(relation.osmId());
-            builder.addRelation(identifier, osmIdentifier, bean, parseTags(relation.tags()));
+            builder.addRelation(identifier, osmIdentifier, bean, parseTags(iso, relation.tags()));
         }
     }
 
@@ -420,8 +442,10 @@ public class TestAtlasHandler implements FieldHandler
         final String completeName = String.format("%s/%s", packageName, resourcePath);
         try
         {
-            field.set(rule, getAtlasFromJsomOsmResource(josmFormat, new ClassResource(completeName),
-                    Paths.get(completeName).getFileName().toString()));
+            field.set(rule,
+                    getAtlasFromJsomOsmResource(josmFormat, new ClassResource(completeName),
+                            Paths.get(completeName).getFileName().toString(),
+                            field.getAnnotation(TestAtlas.class).iso()));
         }
         catch (IllegalArgumentException | IllegalAccessException e)
         {

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/AtlasTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/AtlasTestCase.java
@@ -14,6 +14,7 @@ import org.openstreetmap.atlas.utilities.collections.Iterables;
  * Example test case illustrating how to use custom rules, and {@link TestAtlasHandler} unit tests.
  *
  * @author cstaylor
+ * @author bbreithaupt
  */
 public class AtlasTestCase
 {

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/AtlasTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/AtlasTestCase.java
@@ -5,10 +5,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 
 /**
- * Example test case illustrating how to use custom rules
+ * Example test case illustrating how to use custom rules, and {@link TestAtlasHandler} unit tests.
  *
  * @author cstaylor
  */
@@ -16,6 +19,35 @@ public class AtlasTestCase
 {
     @Rule
     public AtlasTestCaseRule setup = new AtlasTestCaseRule();
+
+    @Test
+    public void allAnnotationsISOOverrideTest()
+    {
+        final Atlas atlas = this.setup.allAnnotationsISOOverrideAtlas();
+        Assert.assertEquals(9, Iterables.asList(atlas.entities(
+                atlasEntity -> atlasEntity.getTag(ISOCountryTag.KEY).orElse("").equals("DEU")))
+                .size());
+        Assert.assertEquals(1, Iterables.asList(atlas.entities(
+                atlasEntity -> atlasEntity.getTag(ISOCountryTag.KEY).orElse("").equals("BBH")))
+                .size());
+    }
+
+    @Test
+    public void allAnnotationsISOTest()
+    {
+        Assert.assertEquals(10, Iterables.asList(this.setup.allAnnotationsISOAtlas().entities(
+                atlasEntity -> atlasEntity.getTag(ISOCountryTag.KEY).orElse("").equals("DEU")))
+                .size());
+    }
+
+    @Test
+    public void allAnnotationsTest()
+    {
+        Assert.assertEquals(10,
+                Iterables.asList(this.setup.allAnnotationsAtlas().entities(
+                        atlasEntity -> atlasEntity.getTag(ISOCountryTag.KEY).orElse("").equals("")))
+                        .size());
+    }
 
     @Test
     public void verify()

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/AtlasTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/AtlasTestCaseRule.java
@@ -16,6 +16,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
  * {@link TestAtlasHandler} unit test rule.
  *
  * @author cstaylor
+ * @author bbreithaupt
  */
 public class AtlasTestCaseRule extends CoreTestRule
 {

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/AtlasTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/AtlasTestCaseRule.java
@@ -2,15 +2,27 @@ package org.openstreetmap.atlas.utilities.testing;
 
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Building;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
- * Example test case rule showing how annotation processing can simplify test code
+ * Example test case rule showing how annotation processing can simplify test code, and
+ * {@link TestAtlasHandler} unit test rule.
  *
  * @author cstaylor
  */
 public class AtlasTestCaseRule extends CoreTestRule
 {
+    private static final String TEST_1 = "50.2722020136163,7.64883186874144";
+    private static final String TEST_2 = "50.2718530548889,7.64920738356862";
+    private static final String TEST_3 = "50.2722620153118,7.64926173439887";
+
     @TestAtlas(areas = { @Area(id = "1234", tags = { "name=17", "building=apartments",
             "addr:street=Expreso V Centenario" }, coordinates = { @Loc("18.4762695,-69.9118829"),
                     @Loc(lon = -69.3320129, lat = 19.2025913) }) })
@@ -27,6 +39,97 @@ public class AtlasTestCaseRule extends CoreTestRule
      */
     @TestAtlas(areas = { @Area(tags = { "name=42" }) })
     private Atlas atlas3;
+
+    @TestAtlas(
+            // Points
+            points = { @Point(coordinates = @Loc(TEST_2), tags = { "name=Marksburg",
+                    "historic=castle" }) },
+            // Nodes
+            nodes = { @Node(coordinates = @Loc(TEST_1)), @Node(coordinates = @Loc(TEST_3)) },
+            // Edges
+            edges = { @Edge(coordinates = { @Loc(TEST_1), @Loc(TEST_3) }, tags = {
+                    "highway=footway" }) },
+            // Lines
+            lines = { @Line(coordinates = { @Loc(TEST_1), @Loc(TEST_3) }, tags = {
+                    "barrier=retaining_wall" }) },
+            // Areas
+            areas = { @Area(id = "1000000", coordinates = { @Loc(TEST_1), @Loc(TEST_2),
+                    @Loc(TEST_3) }, tags = { "building=yes" }) },
+            // Relations
+            relations = { @Relation(members = {
+                    @Member(id = "1000000", type = "area", role = "outer") }, tags = {
+                            "type=multipolygon", "building=yes" }) },
+            // Buildings
+            buildings = { @Building(outer = @Area(coordinates = { @Loc(TEST_1), @Loc(TEST_2),
+                    @Loc(TEST_3) }), tags = "building=yes") })
+    private Atlas allAnnotationsAtlas;
+
+    @TestAtlas(
+            // Points
+            points = { @Point(coordinates = @Loc(TEST_2), tags = { "name=Marksburg",
+                    "historic=castle" }) },
+            // Nodes
+            nodes = { @Node(coordinates = @Loc(TEST_1)), @Node(coordinates = @Loc(TEST_3)) },
+            // Edges
+            edges = { @Edge(coordinates = { @Loc(TEST_1), @Loc(TEST_3) }, tags = {
+                    "highway=footway" }) },
+            // Lines
+            lines = { @Line(coordinates = { @Loc(TEST_1), @Loc(TEST_3) }, tags = {
+                    "barrier=retaining_wall" }) },
+            // Areas
+            areas = { @Area(id = "1000000", coordinates = { @Loc(TEST_1), @Loc(TEST_2),
+                    @Loc(TEST_3) }, tags = { "building=yes" }) },
+            // Relations
+            relations = { @Relation(members = {
+                    @Member(id = "1000000", type = "area", role = "outer") }, tags = {
+                            "type=multipolygon", "building=yes" }) },
+            // Buildings
+            buildings = { @Building(outer = @Area(coordinates = { @Loc(TEST_1), @Loc(TEST_2),
+                    @Loc(TEST_3) }), tags = "building=yes") },
+            // ISO code
+            iso = "DEU")
+    private Atlas allAnnotationsISOAtlas;
+
+    @TestAtlas(
+            // Points
+            points = { @Point(coordinates = @Loc(TEST_2), tags = { "name=Marksburg",
+                    "historic=castle", "iso_country_code=BBH" }) },
+            // Nodes
+            nodes = { @Node(coordinates = @Loc(TEST_1)), @Node(coordinates = @Loc(TEST_3)) },
+            // Edges
+            edges = { @Edge(coordinates = { @Loc(TEST_1), @Loc(TEST_3) }, tags = {
+                    "highway=footway" }) },
+            // Lines
+            lines = { @Line(coordinates = { @Loc(TEST_1), @Loc(TEST_3) }, tags = {
+                    "barrier=retaining_wall" }) },
+            // Areas
+            areas = { @Area(id = "1000000", coordinates = { @Loc(TEST_1), @Loc(TEST_2),
+                    @Loc(TEST_3) }, tags = { "building=yes" }) },
+            // Relations
+            relations = { @Relation(members = {
+                    @Member(id = "1000000", type = "area", role = "outer") }, tags = {
+                            "type=multipolygon", "building=yes" }) },
+            // Buildings
+            buildings = { @Building(outer = @Area(coordinates = { @Loc(TEST_1), @Loc(TEST_2),
+                    @Loc(TEST_3) }), tags = "building=yes") },
+            // ISO code
+            iso = "DEU")
+    private Atlas allAnnotationsISOOverrideAtlas;
+
+    public Atlas allAnnotationsAtlas()
+    {
+        return this.allAnnotationsAtlas;
+    }
+
+    public Atlas allAnnotationsISOAtlas()
+    {
+        return this.allAnnotationsISOAtlas;
+    }
+
+    public Atlas allAnnotationsISOOverrideAtlas()
+    {
+        return this.allAnnotationsISOOverrideAtlas;
+    }
 
     public Atlas atlas()
     {

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/TestAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/TestAtlasTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,19 +13,45 @@ import org.slf4j.LoggerFactory;
  * Tests {@link Atlas} creation from both JOSM and Osmosis XML files.
  *
  * @author matthieun
+ * @author bbreithaupt
  */
 public class TestAtlasTest
 {
     private static final Logger logger = LoggerFactory.getLogger(TestAtlasTest.class);
+    private static final String USA = "USA";
 
     @Rule
     public final TestAtlasTestRule rule = new TestAtlasTestRule();
+
+    @Test
+    public void loadFromJosmOsmResourceISOTest()
+    {
+        final Atlas atlas = this.rule.getAtlasFromJosmOsmResourceISO();
+        assertAtlasCreation(atlas);
+        Assert.assertEquals(14,
+                Iterables
+                        .asList(atlas.entities(
+                                entity -> entity.getTag(ISOCountryTag.KEY).orElse("").equals(USA)))
+                        .size());
+    }
 
     @Test
     public void loadFromJosmOsmResourceTest()
     {
         final Atlas atlas = this.rule.getAtlasFromJosmOsmResource();
         assertAtlasCreation(atlas);
+    }
+
+    @Test
+    public void loadFromOsmResourceISOTest()
+    {
+        final Atlas atlas = this.rule.getAtlasFromOsmResourceISO();
+        assertAtlasCreation(atlas);
+        Assert.assertEquals(14,
+                Iterables
+                        .asList(atlas.entities(
+                                entity -> entity.getTag(ISOCountryTag.KEY).orElse("").equals(USA)))
+                        .size());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/TestAtlasTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/TestAtlasTestRule.java
@@ -6,6 +6,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
  * {@link TestAtlasTest} test data
  *
  * @author matthieun
+ * @author bbreithaupt
  */
 public class TestAtlasTestRule extends CoreTestRule
 {
@@ -15,13 +16,29 @@ public class TestAtlasTestRule extends CoreTestRule
     @TestAtlas(loadFromOsmResource = "osmFile.osm")
     private Atlas atlasFromOsmResource;
 
+    @TestAtlas(loadFromJosmOsmResource = "josmOsmFile.osm", iso = "USA")
+    private Atlas atlasFromJosmOsmResourceISO;
+
+    @TestAtlas(loadFromOsmResource = "osmFile.osm", iso = "USA")
+    private Atlas atlasFromOsmResourceISO;
+
     public Atlas getAtlasFromJosmOsmResource()
     {
         return this.atlasFromJosmOsmResource;
     }
 
+    public Atlas getAtlasFromJosmOsmResourceISO()
+    {
+        return this.atlasFromJosmOsmResourceISO;
+    }
+
     public Atlas getAtlasFromOsmResource()
     {
         return this.atlasFromOsmResource;
+    }
+
+    public Atlas getAtlasFromOsmResourceISO()
+    {
+        return this.atlasFromOsmResourceISO;
     }
 }


### PR DESCRIPTION
### Description:

Currently there is no easy way to apply an ISO country code to all features when creating a test atlas. When using annotations it is possible to add ISO codes by manually adding them to each feature. When importing from a resource the recourse file itself must be edited to add the tag for the codes. This becomes quite cumbersome when working with large test cases that require every feature to have an ISO country code. 
This fixes this problem by tweaking the behavior of the `iso` property of the `TestAtlas` annotation. Previously this property just updated the atlas meta data to include the ISO code. Now this code is applied as a tag to all features in the test atlas, whether they are from an annotation or a resource (excluding text atlases).

### Potential Impact:

The largest potential impacts are mitigated by maintaining the do nothing if `unknown` logic. This way the ISO tags are only added when the `iso` parameter is added to a `TestAtlas` annotation. 
This is still a potentially breaking change if there is something using the `iso` parameter and is expecting a lack of ISO tags or a certain tag count/set of tags.   
It is also possible that the addition of country slicing when iso code are passed could have an impact. However no real slicing is done becasue the country boundary map that is used contains `Rectangle.MAXIMUM` as the only 'country'.

### Unit Test Approach:

Added unit tests to `AtlasTestCase` to check that this works for annotation test atlases.
Added unit tests to `TestAtlasTest` to check that this works for resources imported as test atlases. 

### Test Results:

None

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
